### PR TITLE
[chore] 커스텀 예외 및 에러 코드/응답 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,8 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/school/mohitto/exception/CustomException.java
+++ b/src/main/java/com/school/mohitto/exception/CustomException.java
@@ -1,0 +1,11 @@
+package com.school.mohitto.exception;
+
+import com.school.mohitto.exception.code.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/com/school/mohitto/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/school/mohitto/exception/GlobalExceptionHandler.java
@@ -1,0 +1,150 @@
+package com.school.mohitto.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.school.mohitto.exception.code.ErrorCode;
+import com.school.mohitto.exception.dto.ErrorResponse;
+import jakarta.validation.ConstraintViolationException;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @Override
+    protected ResponseEntity<Object> handleExceptionInternal(
+            Exception ex,
+            Object body,
+            HttpHeaders headers,
+            HttpStatusCode statusCode,
+            WebRequest request) {
+            ErrorResponse errorResponse =
+                ErrorResponse.of(HttpStatus.resolve(statusCode.value()), ex.getMessage());
+        return super.handleExceptionInternal(ex, errorResponse, headers, statusCode, request);
+    }
+
+    /**
+     * javax.validation.Valid or @Validated 으로 binding error 발생시 발생한다. HttpMessageConverter 에서 등록한
+     * HttpMessageConverter binding 못할경우 발생 주로 @RequestBody, @RequestPart 어노테이션에서 발생
+     */
+    @SneakyThrows
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException e,
+            HttpHeaders headers,
+            HttpStatusCode status,
+            WebRequest request) {
+        log.error("MethodArgumentNotValidException : {}", e.getMessage(), e);
+        List<FieldError> errors = e.getBindingResult().getFieldErrors();
+        Map<String, Object> fieldAndErrorMessages =
+                errors.stream()
+                        .collect(
+                                Collectors.toMap(
+                                        FieldError::getField, FieldError::getDefaultMessage));
+
+        String errorsToJsonString = new ObjectMapper().writeValueAsString(fieldAndErrorMessages);
+        final ErrorResponse errorResponse =
+                ErrorResponse.of(HttpStatus.resolve(status.value()), errorsToJsonString);
+
+        return ResponseEntity.status(errorResponse.status()).body(errorResponse);
+    }
+
+    /** Request Param Validation 예외 처리 */
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handleConstraintViolationException(
+            ConstraintViolationException e) {
+        log.error("ConstraintViolationException : {}", e.getMessage(), e);
+
+        Map<String, Object> bindingErrors = new HashMap<>();
+        e.getConstraintViolations()
+                .forEach(
+                        constraintViolation -> {
+                            List<String> propertyPath =
+                                    List.of(
+                                            constraintViolation
+                                                    .getPropertyPath()
+                                                    .toString()
+                                                    .split("\\."));
+                            String path =
+                                    propertyPath.stream()
+                                            .skip(propertyPath.size() - 1L)
+                                            .findFirst()
+                                            .orElse(null);
+                            bindingErrors.put(path, constraintViolation.getMessage());
+                        });
+
+        final ErrorResponse errorResponse =
+                ErrorResponse.of(HttpStatus.BAD_REQUEST, bindingErrors.toString());
+
+        return ResponseEntity.status(errorResponse.status()).body(errorResponse);
+    }
+
+    /** enum type 일치하지 않아 binding 못할 경우 발생 주로 @RequestParam enum으로 binding 못했을 경우 발생 */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(
+            MethodArgumentTypeMismatchException e) {
+        log.error("MethodArgumentTypeMismatchException : {}", e.getMessage(), e);
+        final ErrorCode errorCode = ErrorCode.METHOD_ARGUMENT_TYPE_MISMATCH;
+        final ErrorResponse errorResponse =
+                ErrorResponse.of(errorCode.getStatus(), errorCode.getMessage());
+
+        return ResponseEntity.status(errorResponse.status()).body(errorResponse);
+    }
+
+    /** 지원하지 않은 HTTP method 호출 할 경우 발생 */
+    @Override
+    protected ResponseEntity<Object> handleHttpRequestMethodNotSupported(
+            HttpRequestMethodNotSupportedException e,
+            HttpHeaders headers,
+            HttpStatusCode status,
+            WebRequest request) {
+        log.error("HttpRequestMethodNotSupportedException : {}", e.getMessage(), e);
+        final ErrorCode errorCode = ErrorCode.METHOD_NOT_ALLOWED;
+        final ErrorResponse errorResponse =
+                ErrorResponse.of(errorCode.getStatus(), errorCode.getMessage());
+
+        return ResponseEntity.status(errorResponse.status()).body(errorResponse);
+    }
+
+    /** CustomException 예외 처리 */
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+        log.error("CustomException : {}", e.getMessage(), e);
+        final ErrorCode errorCode = e.getErrorCode();
+        final ErrorResponse errorResponse =
+                ErrorResponse.of(errorCode.getStatus(), errorCode.getMessage());
+
+        return ResponseEntity.status(errorResponse.status()).body(errorResponse);
+    }
+
+    /** 500번대 에러 처리 */
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("Internal Server Error : {}", e.getMessage(), e);
+        final ErrorCode internalServerError = ErrorCode.INTERNAL_SERVER_ERROR;
+        final ErrorResponse errorResponse =
+                ErrorResponse.of(internalServerError.getStatus(), internalServerError.getMessage());
+
+        return ResponseEntity.status(errorResponse.status()).body(errorResponse);
+    }
+}

--- a/src/main/java/com/school/mohitto/exception/code/ErrorCode.java
+++ b/src/main/java/com/school/mohitto/exception/code/ErrorCode.java
@@ -1,0 +1,24 @@
+package com.school.mohitto.exception.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+    BAD_REQUEST(HttpStatus.BAD_REQUEST,  "잘못된 요청입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED,  "인증이 필요합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN,  "금지된 요청입니다."),
+    INVALID_REQUEST_INFO(HttpStatus.BAD_REQUEST,  "요청된 정보가 올바르지 않습니다."),
+    VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "유효성 검증에 실패했습니다."),
+    INVALID_PARAMETER(HttpStatus.BAD_REQUEST,  "유효하지 않은 파라미터입니다."),
+    METHOD_ARGUMENT_TYPE_MISMATCH(HttpStatus.BAD_REQUEST,"Enum Type이 일치하지 않아 Binding에 실패하였습니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED,"지원하지 않는 HTTP method 입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,  "서버 에러, 관리자에게 문의 바랍니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/school/mohitto/exception/dto/ErrorResponse.java
+++ b/src/main/java/com/school/mohitto/exception/dto/ErrorResponse.java
@@ -5,12 +5,13 @@ import org.springframework.http.HttpStatus;
 import java.time.LocalDateTime;
 
 public record ErrorResponse(
+        boolean isSuccess,
         int status,
         String message,
         LocalDateTime timestamp
 ) {
 
     public static ErrorResponse of(HttpStatus status, String message) {
-        return new ErrorResponse(status.value(), message, LocalDateTime.now());
+        return new ErrorResponse(false,status.value(), message, LocalDateTime.now());
     }
 }

--- a/src/main/java/com/school/mohitto/exception/dto/ErrorResponse.java
+++ b/src/main/java/com/school/mohitto/exception/dto/ErrorResponse.java
@@ -1,0 +1,16 @@
+package com.school.mohitto.exception.dto;
+
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+
+public record ErrorResponse(
+        int status,
+        String message,
+        LocalDateTime timestamp
+) {
+
+    public static ErrorResponse of(HttpStatus status, String message) {
+        return new ErrorResponse(status.value(), message, LocalDateTime.now());
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈

- close #5

---
## 📌 작업 내용 및 특이사항

- validation 의존성 추가
- GlobalExceptionHandler 생성
- 스프링 예외를 미리 처리해둔 ResponseEntityExceptionHandle를 상속 받아 사용
- "isSuccess", "status", "message", "timestamp" 형식으로 응답 통일

---
## 📚 참고사항

- https://kkongchii.tistory.com/entry/Spring-Boot-ExceptionHandler-ControllerAdvice-Exception-공통-처리