### PR TITLE
[Bug] 카카오 회원 이메일 정보 가져오도록 수정

### DIFF
--- a/src/main/java/com/school/mohitto/domain/User.java
+++ b/src/main/java/com/school/mohitto/domain/User.java
@@ -26,6 +26,9 @@ public class User {
     @Column(length = MAX_NAME_LENGTH)
     private String name;
 
+    @Column(unique = true)
+    private String email;
+
     @Column(nullable = false)
     private String profileImageUrl;
 
@@ -46,8 +49,9 @@ public class User {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<UserSalon> userSalons = new ArrayList<>();
 
-    public User(String name, String profileImageUrl, String oauth2Id, OAuth2Type oauth2Type) {
+    public User(String name, String email, String profileImageUrl, String oauth2Id, OAuth2Type oauth2Type) {
         this.name = name;
+        this.email = email;
         this.profileImageUrl = profileImageUrl;
         this.oauth2Id = oauth2Id;
         this.oauth2Type = oauth2Type;

--- a/src/main/java/com/school/mohitto/domain/authentication/OAuth2UserInfo.java
+++ b/src/main/java/com/school/mohitto/domain/authentication/OAuth2UserInfo.java
@@ -5,6 +5,7 @@ public record OAuth2UserInfo(
         String oauth2Id,
         OAuth2Type oauth2Type,
         String nickname,
+        String email,
         String profileImageUrl
 ) {
 }

--- a/src/main/java/com/school/mohitto/domain/authentication/dto/KakaoUserInfoResponseDto.java
+++ b/src/main/java/com/school/mohitto/domain/authentication/dto/KakaoUserInfoResponseDto.java
@@ -5,7 +5,6 @@ import java.util.Map;
 public record KakaoUserInfoResponseDto (
         String id,
         Map<String, Object> properties,
-        String nickname,
-        String profile_image
+        Map<String, Object> kakao_account
 ){
 }

--- a/src/main/java/com/school/mohitto/security/oauth2/KakaoOAuth2Handler.java
+++ b/src/main/java/com/school/mohitto/security/oauth2/KakaoOAuth2Handler.java
@@ -78,6 +78,7 @@ public class KakaoOAuth2Handler implements OAuth2Handler {
 
         return new OAuth2UserInfo(response.id(),OAuth2Type.KAKAO,
                 (String) response.properties().get("nickname"),
+                (String) response.kakao_account().get("email"),
                 (String) response.properties().get("profile_image")
         );
     }

--- a/src/main/java/com/school/mohitto/service/authentication/AuthenticationService.java
+++ b/src/main/java/com/school/mohitto/service/authentication/AuthenticationService.java
@@ -10,11 +10,13 @@ import com.school.mohitto.repository.BlackListTokenRepository;
 import com.school.mohitto.repository.UserRepository;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -53,6 +55,7 @@ public class AuthenticationService {
         ).orElseGet(() -> {
             User newUser = new User(
                     oauth2UserInfo.nickname(),
+                    oauth2UserInfo.email(),
                     oauth2UserInfo.profileImageUrl(),
                     oauth2UserInfo.oauth2Id(),
                     oauth2UserInfo.oauth2Type()


### PR DESCRIPTION
## 🌱 관련 이슈

- close #38 

---
## 📌 작업 내용 및 특이사항

- 카카오에서 회원 정보 가져올때 이메일 정보도 가져오도록 수정
- 추후 마이페이지- 회원 정보 개발할 예정

---
## 📚 참고사항

-